### PR TITLE
Display number of likes for each item on the Homepage :heart: 

### DIFF
--- a/src/modules/APIs/likes.js
+++ b/src/modules/APIs/likes.js
@@ -1,0 +1,8 @@
+const involvementURL =
+  "https://us-central1-involvement-api.cloudfunctions.net/capstoneApi/apps/8ev0fUwJNQWCM4y1a4xa/likes/";
+
+export const getLikes = async () => {
+  const response = await fetch(involvementURL);
+  const data = await response.json();
+  return data;
+};

--- a/src/modules/APIs/likes.js
+++ b/src/modules/APIs/likes.js
@@ -1,8 +1,9 @@
-const involvementURL =
-  "https://us-central1-involvement-api.cloudfunctions.net/capstoneApi/apps/8ev0fUwJNQWCM4y1a4xa/likes/";
+const involvementURL = 'https://us-central1-involvement-api.cloudfunctions.net/capstoneApi/apps/8ev0fUwJNQWCM4y1a4xa/likes/';
 
-export const getLikes = async () => {
+const getLikes = async () => {
   const response = await fetch(involvementURL);
   const data = await response.json();
   return data;
 };
+
+export default getLikes;

--- a/src/modules/renderPokemons.js
+++ b/src/modules/renderPokemons.js
@@ -1,9 +1,10 @@
-import { getPokemonsData, getPokemonData } from './APIs/pokemon.js';
+import { getLikes } from "./APIs/likes.js";
+import { getPokemonsData, getPokemonData } from "./APIs/pokemon.js";
 
-const section = document.querySelector('section.pokemon-cards');
+const section = document.querySelector("section.pokemon-cards");
 
 // create pokemon card
-const renderPokemonCard = ({ name, url }) => `
+const renderPokemonCard = ({ name, url, likes, index }) => `
   <div class="pokemon-card">
     <img class="pokemon-card-image" src="${url}" alt="${name}">
     <div class="pokemon-card-header">
@@ -13,21 +14,36 @@ const renderPokemonCard = ({ name, url }) => `
       <p></p>
     </div>
     <div class="pokemon-card-button">
-      <button class="like">
-      <div style="background-color: transparent;">
-        <svg viewBox="0 0 17.503 15.625" height="20.625" width="20.503" xmlns="http://www.w3.org/2000/svg" class="icon">
-            <path transform="translate(0 0)" d="M8.752,15.625h0L1.383,8.162a4.824,4.824,0,0,1,0-6.762,4.679,4.679,0,0,1,6.674,0l.694.7.694-.7a4.678,4.678,0,0,1,6.675,0,4.825,4.825,0,0,1,0,6.762L8.752,15.624ZM4.72,1.25A3.442,3.442,0,0,0,2.277,2.275a3.562,3.562,0,0,0,0,5l6.475,6.556,6.475-6.556a3.563,3.563,0,0,0,0-5A3.443,3.443,0,0,0,12.786,1.25h-.01a3.415,3.415,0,0,0-2.443,1.038L8.752,3.9,7.164,2.275A3.442,3.442,0,0,0,4.72,1.25Z" id="Fill" fill="royalblue"></path>
-        </svg>
-     </div>
-      </button>
+        <div>
+            <button class="like">
+                <div style="background-color: transparent;">
+                    <svg viewBox="0 0 17.503 15.625" height="20.625" width="20.503" xmlns="http://www.w3.org/2000/svg" class="icon">
+                    <path transform="translate(0 0)" d="M8.752,15.625h0L1.383,8.162a4.824,4.824,0,0,1,0-6.762,4.679,4.679,0,0,1,6.674,0l.694.7.694-.7a4.678,4.678,0,0,1,6.675,0,4.825,4.825,0,0,1,0,6.762L8.752,15.624ZM4.72,1.25A3.442,3.442,0,0,0,2.277,2.275a3.562,3.562,0,0,0,0,5l6.475,6.556,6.475-6.556a3.563,3.563,0,0,0,0-5A3.443,3.443,0,0,0,12.786,1.25h-.01a3.415,3.415,0,0,0-2.443,1.038L8.752,3.9,7.164,2.275A3.442,3.442,0,0,0,4.72,1.25Z" id="Fill" fill="royalblue"></path>
+                    </svg>
+                </div>
+            </button>
+            <p class="pokemon-index-${index}">${likes}</p>
+        </div>
       <button type="button" class="full-rounded" id="comment">Comments<div class="border full-rounded"></div></button>
     </div>
   </div>
 `;
 
-// Renders an array of pokemon cards
-const renderPokemonCards = (listOfPokemons) => {
-  const pokemonDetail = listOfPokemons.map(renderPokemonCard).join('');
+const renderPokemonCards = async (listOfPokemons) => {
+  // Retrieve the list of likes data using the getLikes function.
+  const likesData = await getLikes();
+  // Map over the list of Pokemons and add the corresponding likes data to each Pokemon object.
+  const updatedPokemons = listOfPokemons.map((pokemon, index) => {
+    const likes = likesData.find((data) => data.item_id === String(index + 1));
+    return {
+      ...pokemon,
+      likes: likes ? likes.likes : 0,
+      index,
+    };
+  });
+  // Generate the HTML for each updated Pokemon card and join the resulting strings together.
+  const pokemonDetail = updatedPokemons.map(renderPokemonCard).join("");
+  // Insert the HTML string into the section element.
   section.innerHTML = pokemonDetail;
 };
 
@@ -35,7 +51,9 @@ const renderPokemonCards = (listOfPokemons) => {
 const fetchPokemonData = async () => {
   try {
     const pokemonBaseData = await getPokemonsData();
-    const promisesArray = pokemonBaseData.map(async ({ url }) => getPokemonData(url));
+    const promisesArray = pokemonBaseData.map(async ({ url }) =>
+      getPokemonData(url)
+    );
     const urlsImgArray = await Promise.all(promisesArray);
     const pokemonArray = pokemonBaseData.map(({ name }, i) => ({
       name,
@@ -48,10 +66,13 @@ const fetchPokemonData = async () => {
   }
 };
 
-// Define main function ------------------------------------------------------------------------
+// Define main function
 const main = async () => {
   const listOfPokemons = await fetchPokemonData();
   renderPokemonCards(listOfPokemons);
+  const test = await getLikes();
+  //   console.log(test);
+  //   console.log(listOfPokemons);
 };
 
 export default main;

--- a/src/modules/renderPokemons.js
+++ b/src/modules/renderPokemons.js
@@ -1,10 +1,12 @@
-import { getLikes } from "./APIs/likes.js";
-import { getPokemonsData, getPokemonData } from "./APIs/pokemon.js";
+import getLikes from './APIs/likes.js';
+import { getPokemonsData, getPokemonData } from './APIs/pokemon.js';
 
-const section = document.querySelector("section.pokemon-cards");
+const section = document.querySelector('section.pokemon-cards');
 
 // create pokemon card
-const renderPokemonCard = ({ name, url, likes, index }) => `
+const renderPokemonCard = ({
+  name, url, likes, index,
+}) => `
   <div class="pokemon-card">
     <img class="pokemon-card-image" src="${url}" alt="${name}">
     <div class="pokemon-card-header">
@@ -42,7 +44,7 @@ const renderPokemonCards = async (listOfPokemons) => {
     };
   });
   // Generate the HTML for each updated Pokemon card and join the resulting strings together.
-  const pokemonDetail = updatedPokemons.map(renderPokemonCard).join("");
+  const pokemonDetail = updatedPokemons.map(renderPokemonCard).join('');
   // Insert the HTML string into the section element.
   section.innerHTML = pokemonDetail;
 };
@@ -51,9 +53,7 @@ const renderPokemonCards = async (listOfPokemons) => {
 const fetchPokemonData = async () => {
   try {
     const pokemonBaseData = await getPokemonsData();
-    const promisesArray = pokemonBaseData.map(async ({ url }) =>
-      getPokemonData(url)
-    );
+    const promisesArray = pokemonBaseData.map(async ({ url }) => getPokemonData(url));
     const urlsImgArray = await Promise.all(promisesArray);
     const pokemonArray = pokemonBaseData.map(({ name }, i) => ({
       name,
@@ -70,9 +70,6 @@ const fetchPokemonData = async () => {
 const main = async () => {
   const listOfPokemons = await fetchPokemonData();
   renderPokemonCards(listOfPokemons);
-  const test = await getLikes();
-  //   console.log(test);
-  //   console.log(listOfPokemons);
 };
 
 export default main;

--- a/src/styles.css
+++ b/src/styles.css
@@ -171,3 +171,9 @@ button:hover .border {
 .like {
   background-color: transparent;
 }
+
+.pokemon-card-button > div:first-child {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}


### PR DESCRIPTION
# Fetching and Displaying Pokemon Likes from API #12  :eyes: :heart: 

This pull request aims to display the number of likes for each card using the Involvement API. :tada: The app should only make two requests, one to the base API and one to the Involvement API, to combine the data and show the total likes for each card upon loading the web page. :computer: It's worth noting that this task does not require displaying the likes button (heart icon on the wireframe) for each card. :no_entry_sign:

## Tasks' List :memo: 
- [x] Use the Involvement API to display the number of likes for each Pokemon card :sparkles:
- [x] Make only 2 requests when the web page loads - one to the base API and one to the Involvement API :computer:

> _Note that displaying the likes button (heart icon on the wireframe) for each card is not part of this task :no_entry_sign:_
